### PR TITLE
tweak type definition for SAXParser

### DIFF
--- a/lib/saxWasm.d.ts
+++ b/lib/saxWasm.d.ts
@@ -83,12 +83,12 @@ export declare class SAXParser {
     events: number;
     eventHandler: (type: SaxEventType, detail: Detail) => void;
     private readonly options;
-    private wasmSaxParser;
+    wasmSaxParser?: WebAssembly.Exports;
     private writeBuffer;
     constructor(events?: number, options?: SaxParserOptions);
     write(chunk: Uint8Array): void;
     end(): void;
     prepareWasm(saxWasm: Uint8Array): Promise<boolean>;
-    protected eventTrap: (event: number, ptr: number, len: number) => void;
+    eventTrap: (event: number, ptr: number, len: number) => void;
 }
 export {};


### PR DESCRIPTION
To use sax-wasm on cloudflare workers, I need the following instead of simply using `prepareWasm`.

```ts
declare const WASM_MODULE: WebAssembly.Module

function load_wasm(parser: SAXParser): void {
  const instance = new WebAssembly.Instance(WASM_MODULE, {
    env: {
      memoryBase: 0,
      tableBase: 0,
      memory: new WebAssembly.Memory({ initial: 10 }),
      table: new WebAssembly.Table({ initial: 1, element: 'anyfunc' }),
      event_listener: parser.eventTrap
    }
  })
  parser.wasmSaxParser = instance.exports
  const wasm_parser = instance.exports.parser as (v: number) => void
  wasm_parser(parser.events)
}
```

(it's effectively a rewrite of `prepareWasm`)

However typescript throws errors since `eventTrap` and `wasmSaxParser` aren't public.

This PR makes them both public. I've also added a type to `wasmSaxParser`.