### PR TITLE
SAXParser: write: Clear fragments after prepending to current source

### DIFF
--- a/src/sax/parser.rs
+++ b/src/sax/parser.rs
@@ -60,6 +60,7 @@ impl SAXParser {
     pub fn write(&mut self, source: &[u8]) {
         let mut idx = 0;
         let mut chunk = self.fragment.clone();
+        self.fragment.clear();
         chunk.extend_from_slice(source);
         let len = chunk.len();
 
@@ -78,7 +79,6 @@ impl SAXParser {
             // We don't have enough bytes
             let end_idx = idx + bytes;
             if end_idx > len {
-                self.fragment.truncate(0);
                 loop {
                     self.fragment.push(chunk[idx]);
                     idx += 1;


### PR DESCRIPTION
Currently, when a chunk ends with an incomplete UTF-8 sequence, the bytes are stored in self.fragment and prepended to the next chunk.
However, after prepending the bytes, self.fragments isn't cleared in all cases. This leads to a corruption of all future chunks, as the same incomplete UTF-8 sequence is prepended to every chunk until there's another incomplete UTF-8 sequence at the end of a chunk.

Therefore, self.fragment is now cleared immediately after prepending the bytes to the next chunk.