### PR TITLE
Support type guards for the output of the parser

### DIFF
--- a/src/js/__test__/cdada.spec.ts
+++ b/src/js/__test__/cdada.spec.ts
@@ -34,6 +34,7 @@ describe('When parsing XML, the SaxWasm', () => {
     deepStrictEqual(JSON.parse(JSON.stringify(start)), { line: 0, character: 5 });
     deepStrictEqual(JSON.parse(JSON.stringify(end)), { line: 0, character: 84 });
     strictEqual(value, 'did you know "x < y" & "z > y"? so I [guess] that means that z > x ');
+    strictEqual(_event, SaxEventType.Cdata);
   });
 
   it('should report cdata (lower case) correctly', () => {
@@ -42,6 +43,7 @@ describe('When parsing XML, the SaxWasm', () => {
     deepStrictEqual(JSON.parse(JSON.stringify(start)), { line: 0, character: 5 });
     deepStrictEqual(JSON.parse(JSON.stringify(end)), { line: 0, character: 83 });
     strictEqual(value, ' did you know "x < y" & "z > y"? so I guess that means that z > x ');
+    strictEqual(_event, SaxEventType.Cdata);
   });
 
   it('should report cDaTa (mixed case) correctly', () => {
@@ -50,6 +52,7 @@ describe('When parsing XML, the SaxWasm', () => {
     deepStrictEqual(JSON.parse(JSON.stringify(start)), { line: 0, character: 5 });
     deepStrictEqual(JSON.parse(JSON.stringify(end)), { line: 0, character: 83 });
     strictEqual(value, ' did you know "x < y" & "z > y"? so I guess that means that z > x ');
+    strictEqual(_event, SaxEventType.Cdata);
   });
 
   it("should support empty cdata", () => {
@@ -66,5 +69,6 @@ describe('When parsing XML, the SaxWasm', () => {
     const [empty, something] = _data;
     strictEqual(empty.value, "");
     strictEqual(something.value, "something");
+    strictEqual(_event, SaxEventType.Cdata);
   });
 });

--- a/src/js/__test__/comment.spec.ts
+++ b/src/js/__test__/comment.spec.ts
@@ -7,7 +7,7 @@ const saxWasm = readFileSync(resolve(__dirname, '../../../lib/sax-wasm.wasm'));
 
 describe('SaxWasm', () => {
     let parser: SAXParser;
-    let _event: SaxEventType;
+    let _event: SaxEventType|undefined;
     let _data: (Attribute & Text & Tag)[];
 
     beforeAll(async () => {
@@ -60,11 +60,13 @@ describe('SaxWasm', () => {
       parser.write(Buffer.from(`<!--name="test 3 attr" some comment--> <!-- name="test 3 attr" some comment -->`));
       strictEqual(_data[0].value, 'name="test 3 attr" some comment');
       strictEqual(_data[1].value, ' name="test 3 attr" some comment ');
+      strictEqual(_event, SaxEventType.Comment);
     });
 
     it ('should allow for chars that look like comment endings but are not really endings', () => {
       parser.events = SaxEventType.Comment;
       parser.write(Buffer.from(`<!--name="test 3 attr" some comment -- > not an ending-->`));
       strictEqual(_data[0].value, 'name="test 3 attr" some comment -- > not an ending');
+      strictEqual(_event, SaxEventType.Comment);
     });
 });

--- a/src/js/__test__/doctype.spec.ts
+++ b/src/js/__test__/doctype.spec.ts
@@ -34,6 +34,7 @@ describe('When parsing XML, the SaxWasm', () => {
     deepEqual(start, { line: 0, character: 0 });
     deepEqual(end, { line: 0, character: 15 });
     strictEqual(value, 'html');
+    strictEqual(_event, SaxEventType.Doctype);
   });
 
   it('should report doctype (lower case) correctly', () => {
@@ -42,6 +43,7 @@ describe('When parsing XML, the SaxWasm', () => {
     deepEqual(start, { line: 0, character: 0 });
     deepEqual(end, { line: 0, character: 15 });
     strictEqual(value, 'html');
+    strictEqual(_event, SaxEventType.Doctype);
   });
 
   it('should report DocType (mixed case) correctly', () => {
@@ -50,5 +52,6 @@ describe('When parsing XML, the SaxWasm', () => {
     deepEqual(start, { line: 0, character: 0 });
     deepEqual(end, { line: 0, character: 15 });
     strictEqual(value, 'html');
+    strictEqual(_event, SaxEventType.Doctype);
   });
 });

--- a/src/js/__test__/text.spec.ts
+++ b/src/js/__test__/text.spec.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
-import { deepStrictEqual } from  'assert';
+import { deepStrictEqual, strictEqual } from  'assert';
 import { Detail, Reader, SaxEventType, SAXParser } from '../saxWasm';
 
 const saxWasm = readFileSync(resolve(__dirname, '../../../lib/sax-wasm.wasm'));
@@ -27,6 +27,7 @@ describe('SaxWasm', () => {
     parser.write(Buffer.from('this is just plain text <br>'));
     parser.end();
     deepStrictEqual(_data[0].value,'this is just plain text ');
+    strictEqual(_event, SaxEventType.Text);
   });
 
   it('should report multiple text blocks when child nodes exist between them', () => {
@@ -36,6 +37,7 @@ describe('SaxWasm', () => {
     deepStrictEqual(_data[0].value,'I like to use ');
     deepStrictEqual(_data[1].value,'bold text');
     deepStrictEqual(_data[2].value,' to emphasize');
+    strictEqual(_event, SaxEventType.Text);
   });
 
   it('should not capture empty white space between tags', () => {
@@ -53,5 +55,6 @@ describe('SaxWasm', () => {
     parser.write(Buffer.from('a happy little parser'));
     parser.end();
     deepStrictEqual(JSON.stringify(_data[0]),'{"start":{"line":0,"character":0},"end":{"line":0,"character":21},"value":"a happy little parser"}');
+    strictEqual(_event, SaxEventType.Text);
   });
 });

--- a/src/sax/parser.rs
+++ b/src/sax/parser.rs
@@ -745,7 +745,7 @@ impl<'a> SAXParser<'a> {
             if self.events[Event::Doctype] && markup_decl.hydrate(self.source_ptr) {
                 markup_decl.value.truncate(markup_decl.value.len() - 1); // remove '>' or '['
 
-                self.event_handler.handle_event(Event::Cdata, Entity::Text(&markup_decl));
+                self.event_handler.handle_event(Event::Doctype, Entity::Text(&markup_decl));
                 self.dispatched.push(Dispatched::Text(markup_decl));
             }
             self.state = State::BeginWhitespace;


### PR DESCRIPTION
I've added support for type guards on the output of the parser by annotating the result of the parser as a discriminating union.

This will help typescript to infer the type of the `Reader` when checking the SaxEventType:
```
for await (const [event, detail] of parser.parse(reader)) {
  if (event === SaxEventType.Attribute) {
    detail.name
  } else if (event === SaxEventType.OpenTag) {
    detail.attributes
  }
}
  ```