### PR TITLE
fix(#108): WASM write creates slice with null pointer

### DIFF
--- a/lib/cjs/saxWasm.js
+++ b/lib/cjs/saxWasm.js
@@ -557,8 +557,8 @@ class SAXParser {
         if (this.writeBuffer?.buffer !== buffer) {
             this.writeBuffer = new Uint8Array(buffer);
         }
-        this.writeBuffer.set(chunk, 0);
-        write(0, chunk.byteLength);
+        this.writeBuffer.set(chunk, 4);
+        write(4, chunk.byteLength);
     }
     /**
      * Ends the parsing process.

--- a/lib/esm/saxWasm.js
+++ b/lib/esm/saxWasm.js
@@ -548,8 +548,8 @@ export class SAXParser {
         if (this.writeBuffer?.buffer !== buffer) {
             this.writeBuffer = new Uint8Array(buffer);
         }
-        this.writeBuffer.set(chunk, 0);
-        write(0, chunk.byteLength);
+        this.writeBuffer.set(chunk, 4);
+        write(4, chunk.byteLength);
     }
     /**
      * Ends the parsing process.

--- a/src/js/__test__/benchmark.mjs
+++ b/src/js/__test__/benchmark.mjs
@@ -1,9 +1,9 @@
-import { createReadStream, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { URL } from 'url';
 import { resolve } from 'path';
 import { Buffer } from 'buffer';
 
-import { SAXParser, SaxEventType } from '../../../lib/esm/index.js';
+import { SAXParser } from '../../../lib/esm/index.js';
 
 import nodeXml from 'node-xml';
 import expat from 'node-expat';
@@ -18,10 +18,7 @@ const chunkLen = 64 * 1024;
 async function benchmarkSaxWasmParser() {
   const saxWasm = readFileSync(resolve(new URL('../../../lib/sax-wasm.wasm', import.meta.url).pathname));
 
-  const parser = new SAXParser(SaxEventType.OpenTag);
-  parser.eventHandler = (event, detail) => {
-    const  j = detail.toJSON();
-  };
+  const parser = new SAXParser();
   await parser.prepareWasm(saxWasm);
 
   let t = process.hrtime();
@@ -37,7 +34,6 @@ async function benchmarkSaxWasmParser() {
 
 async function benchmarkNodeXmlParser() {
   const parser = new nodeXml.SaxParser(() => void 0);
-  const readable = createReadStream(resolve(new URL('./xml.xml', import.meta.url).pathname));
   let t = process.hrtime();
   let offset = 0;
   while (offset < xml.length) {
@@ -76,7 +72,6 @@ async function benchmarkSaxesParser() {
 
 async function benchmarkSaxParser() {
   const parser = sax.createStream();
-  const readable = createReadStream(resolve(new URL('./xml.xml', import.meta.url).pathname));
   let t = process.hrtime();
 
   let offset = 0;

--- a/src/js/saxWasm.ts
+++ b/src/js/saxWasm.ts
@@ -672,8 +672,8 @@ export class SAXParser {
     if (this.writeBuffer?.buffer !== buffer) {
       this.writeBuffer = new Uint8Array(buffer);
     }
-    this.writeBuffer.set(chunk, 0);
-    write(0, chunk.byteLength);
+    this.writeBuffer.set(chunk, 4);
+    write(4, chunk.byteLength);
   }
 
   /**


### PR DESCRIPTION
fixes #108 

This PR reconciles the differences between JS and Rust's memory addressing by advancing the offset by 1 byte on the JS side. `0` is a valid memory address in WASM but is considered a null pointer in Rust.
